### PR TITLE
feat: setFilter/getFilter for layers

### DIFF
--- a/src/filter/filter-parser.android.ts
+++ b/src/filter/filter-parser.android.ts
@@ -1,13 +1,9 @@
-import { IFilterParser } from './filter-parser.common';
-
-export class FilterParser implements IFilterParser {
-    private static readonly parserInstance = new FilterParser();
-
-    parseJson(json: any[]): com.mapbox.mapboxsdk.style.expressions.Expression {
+export class FilterParser {
+    static parseJson(json: any[]): com.mapbox.mapboxsdk.style.expressions.Expression {
         const expression = com.mapbox.mapboxsdk.style.expressions.Expression.Converter.convert(JSON.stringify(json));
         return expression;
     }
-    toJson(filter: com.mapbox.mapboxsdk.style.expressions.Expression): any[] {
+    static toJson(filter: com.mapbox.mapboxsdk.style.expressions.Expression): any[] {
         if (!filter) {
             return null;
         }
@@ -17,9 +13,5 @@ export class FilterParser implements IFilterParser {
         }
 
         return JSON.parse(filter.toString());
-    }
-
-    static get(): FilterParser {
-        return this.parserInstance;
     }
 }

--- a/src/filter/filter-parser.android.ts
+++ b/src/filter/filter-parser.android.ts
@@ -1,4 +1,4 @@
-import { IFilterParser } from "./filter-parser.common";
+import { IFilterParser } from './filter-parser.common';
 
 export class FilterParser implements IFilterParser {
     private static readonly parserInstance = new FilterParser();
@@ -13,7 +13,7 @@ export class FilterParser implements IFilterParser {
         }
 
         if (!(filter instanceof com.mapbox.mapboxsdk.style.expressions.Expression)) {
-            throw "Filter must be a Expression.";
+            throw new Error('Filter must be a Expression.');
         }
 
         return JSON.parse(filter.toString());

--- a/src/filter/filter-parser.android.ts
+++ b/src/filter/filter-parser.android.ts
@@ -1,0 +1,25 @@
+import { IFilterParser } from "./filter-parser.common";
+
+export class FilterParser implements IFilterParser {
+    private static readonly parserInstance = new FilterParser();
+
+    parseJson(json: any[]): com.mapbox.mapboxsdk.style.expressions.Expression {
+        const expression = com.mapbox.mapboxsdk.style.expressions.Expression.Converter.convert(JSON.stringify(json));
+        return expression;
+    }
+    toJson(filter: com.mapbox.mapboxsdk.style.expressions.Expression): any[] {
+        if (!filter) {
+            return null;
+        }
+
+        if (!(filter instanceof com.mapbox.mapboxsdk.style.expressions.Expression)) {
+            throw "Filter must be a Expression.";
+        }
+
+        return JSON.parse(filter.toString());
+    }
+
+    static get(): FilterParser {
+        return this.parserInstance;
+    }
+}

--- a/src/filter/filter-parser.common.ts
+++ b/src/filter/filter-parser.common.ts
@@ -1,4 +1,0 @@
-export interface IFilterParser {
-    parseJson(json: any[]): any;
-    toJson(filter: any): any[];
-}

--- a/src/filter/filter-parser.common.ts
+++ b/src/filter/filter-parser.common.ts
@@ -1,0 +1,4 @@
+export interface IFilterParser {
+    parseJson(json: Array<any>): any;
+    toJson(filter: any): Array<any>;
+}

--- a/src/filter/filter-parser.common.ts
+++ b/src/filter/filter-parser.common.ts
@@ -1,4 +1,4 @@
 export interface IFilterParser {
-    parseJson(json: Array<any>): any;
-    toJson(filter: any): Array<any>;
+    parseJson(json: any[]): any;
+    toJson(filter: any): any[];
 }

--- a/src/filter/filter-parser.ios.ts
+++ b/src/filter/filter-parser.ios.ts
@@ -1,0 +1,34 @@
+import { IFilterParser } from "./filter-parser.common";
+
+export class FilterParser implements IFilterParser {
+    private static readonly parserInstance = new FilterParser();
+
+    parseJson(json: any[]): NSPredicate {
+        const filterStr = NSString.stringWithString(JSON.stringify(json));
+        const filterData = filterStr.dataUsingEncoding(NSUTF8StringEncoding);
+        const filterJson = NSJSONSerialization.JSONObjectWithDataOptionsError(filterData, NSJSONReadingOptions.MutableContainers);
+        const predicateFilter = (NSPredicate as any).predicateWithMGLJSONObject(filterJson);
+
+        return predicateFilter;
+    }
+
+    toJson(filter: NSPredicate): Array<any> {
+        if (!filter) {
+            return null;
+        }
+        
+        if (!(filter instanceof NSPredicate)) {
+            throw "Filter must be a NSPredicate.";
+        }
+
+        const expressionObj = (filter as any).mgl_jsonExpressionObject;
+        const data = NSJSONSerialization.dataWithJSONObjectOptionsError(expressionObj, 0);
+        const expression: any = NSString.alloc().initWithDataEncoding(data, NSUTF8StringEncoding);
+
+        return JSON.parse(expression);
+    }
+
+    static get(): FilterParser {
+        return this.parserInstance;
+    }
+}

--- a/src/filter/filter-parser.ios.ts
+++ b/src/filter/filter-parser.ios.ts
@@ -1,9 +1,5 @@
-import { IFilterParser } from './filter-parser.common';
-
-export class FilterParser implements IFilterParser {
-    private static readonly parserInstance = new FilterParser();
-
-    parseJson(json: any[]): NSPredicate {
+export class FilterParser {
+    static parseJson(json: any[]): NSPredicate {
         const filterStr = NSString.stringWithString(JSON.stringify(json));
         const filterData = filterStr.dataUsingEncoding(NSUTF8StringEncoding);
         const filterJson = NSJSONSerialization.JSONObjectWithDataOptionsError(filterData, NSJSONReadingOptions.MutableContainers);
@@ -12,7 +8,7 @@ export class FilterParser implements IFilterParser {
         return predicateFilter;
     }
 
-    toJson(filter: NSPredicate): any[] {
+    static toJson(filter: NSPredicate): any[] {
         if (!filter) {
             return null;
         }
@@ -26,9 +22,5 @@ export class FilterParser implements IFilterParser {
         const expression: any = NSString.alloc().initWithDataEncoding(data, NSUTF8StringEncoding);
 
         return JSON.parse(expression);
-    }
-
-    static get(): FilterParser {
-        return this.parserInstance;
     }
 }

--- a/src/filter/filter-parser.ios.ts
+++ b/src/filter/filter-parser.ios.ts
@@ -1,4 +1,4 @@
-import { IFilterParser } from "./filter-parser.common";
+import { IFilterParser } from './filter-parser.common';
 
 export class FilterParser implements IFilterParser {
     private static readonly parserInstance = new FilterParser();
@@ -12,13 +12,13 @@ export class FilterParser implements IFilterParser {
         return predicateFilter;
     }
 
-    toJson(filter: NSPredicate): Array<any> {
+    toJson(filter: NSPredicate): any[] {
         if (!filter) {
             return null;
         }
-        
+
         if (!(filter instanceof NSPredicate)) {
-            throw "Filter must be a NSPredicate.";
+            throw new Error('Filter must be a NSPredicate.');
         }
 
         const expressionObj = (filter as any).mgl_jsonExpressionObject;

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -4284,12 +4284,12 @@ export class Layer implements LayerCommon {
         this.instance.setProperties([new com.mapbox.mapboxsdk.style.layers.PropertyValue('visibility', 'none')]);
     }
 
-    public setFilter(filter: Array<any>) {
+    public setFilter(filter: any[]) {
         this.instance.setFilter(FilterParser.get().parseJson(filter));
     }
 
-    public getFilter(): Array<any> {
-        return FilterParser.get().toJson(this.instance.getFilter());;
+    public getFilter(): any[] {
+        return FilterParser.get().toJson(this.instance.getFilter());
     }
 }
 

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -8,6 +8,7 @@ import { request } from '@nativescript-community/perms';
 import { AndroidApplication, Application, Color, File, Trace, Utils, knownFolders, path } from '@nativescript/core';
 import { AndroidActivityBundleEventData, AndroidActivityEventData } from '@nativescript/core/application/application-interfaces';
 import { getImage } from '@nativescript/core/http';
+import { FilterParser } from './filter/filter-parser.android';
 import { GeoUtils } from './geo.utils';
 import {
     AddExtrusionOptions,
@@ -4281,6 +4282,14 @@ export class Layer implements LayerCommon {
 
     public hide(): void {
         this.instance.setProperties([new com.mapbox.mapboxsdk.style.layers.PropertyValue('visibility', 'none')]);
+    }
+
+    public setFilter(filter: Array<any>) {
+        this.instance.setFilter(FilterParser.get().parseJson(filter));
+    }
+
+    public getFilter(): Array<any> {
+        return FilterParser.get().toJson(this.instance.getFilter());;
     }
 }
 

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -4285,11 +4285,11 @@ export class Layer implements LayerCommon {
     }
 
     public setFilter(filter: any[]) {
-        this.instance.setFilter(FilterParser.get().parseJson(filter));
+        this.instance.setFilter(FilterParser.parseJson(filter));
     }
 
     public getFilter(): any[] {
-        return FilterParser.get().toJson(this.instance.getFilter());
+        return FilterParser.toJson(this.instance.getFilter());
     }
 }
 

--- a/src/mapbox.common.ts
+++ b/src/mapbox.common.ts
@@ -487,8 +487,8 @@ export interface LayerCommon {
     visibility(): boolean;
     show(): void;
     hide(): void;
-    setFilter(filter: Array<any>): void;
-    getFilter(): Array<any>;
+    setFilter(filter: any[]): void;
+    getFilter(): any[];
 }
 
 // ------------------------------------------------------------

--- a/src/mapbox.common.ts
+++ b/src/mapbox.common.ts
@@ -487,6 +487,8 @@ export interface LayerCommon {
     visibility(): boolean;
     show(): void;
     hide(): void;
+    setFilter(filter: Array<any>): void;
+    getFilter(): Array<any>;
 }
 
 // ------------------------------------------------------------

--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -3568,13 +3568,13 @@ export class Layer implements LayerCommon {
             // MGLVectorStyleLayer is the base type of many layer types. Predicates only supported on vector style layers.
             // See https://docs.mapbox.com/ios/maps/api/6.3.0/Classes/MGLVectorStyleLayer.html
 
-            this.instance.predicate = FilterParser.get().parseJson(filter);
+            this.instance.predicate = FilterParser.parseJson(filter);
         } else {
             throw new Error('Set filter only support for vector layer.');
         }
     }
 
     getFilter(): any[] {
-        return FilterParser.get().toJson(this.instance.predicate);
+        return FilterParser.toJson(this.instance.predicate);
     }
 }

--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -39,6 +39,7 @@ import {
 import { GeoUtils } from './geo.utils';
 import { iOSNativeHelper } from '@nativescript/core/utils';
 import { getImage } from '@nativescript/core/http';
+import { FilterParser } from './filter/filter-parser.ios';
 
 // Export the enums for devs not using TS
 
@@ -3560,6 +3561,21 @@ export class Layer implements LayerCommon {
 
     hide(): void {
         this.instance.visible = false;
+    }
+
+    setFilter(filter: Array<any>) {
+        if (this.instance instanceof MGLVectorStyleLayer) {
+            // MGLVectorStyleLayer is the base type of many layer types. Predicates only supported on vector style layers.
+            // See https://docs.mapbox.com/ios/maps/api/6.3.0/Classes/MGLVectorStyleLayer.html
+
+            this.instance.predicate = FilterParser.get().parseJson(filter);
+        } else {
+            throw "Set filter only support for vector layer.";
+        }
+    }
+
+    getFilter(): Array<any> {
+        return FilterParser.get().toJson(this.instance.predicate);
     }
 }
   

--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -3563,19 +3563,18 @@ export class Layer implements LayerCommon {
         this.instance.visible = false;
     }
 
-    setFilter(filter: Array<any>) {
+    setFilter(filter: any[]) {
         if (this.instance instanceof MGLVectorStyleLayer) {
             // MGLVectorStyleLayer is the base type of many layer types. Predicates only supported on vector style layers.
             // See https://docs.mapbox.com/ios/maps/api/6.3.0/Classes/MGLVectorStyleLayer.html
 
             this.instance.predicate = FilterParser.get().parseJson(filter);
         } else {
-            throw "Set filter only support for vector layer.";
+            throw new Error('Set filter only support for vector layer.');
         }
     }
 
-    getFilter(): Array<any> {
+    getFilter(): any[] {
         return FilterParser.get().toJson(this.instance.predicate);
     }
 }
-  


### PR DESCRIPTION
Hey guys, I have a filter parser implemented to support layer filters like [mapbox expression style](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/).

**New methods:**
* Layer.setFilter(expression)
* Layer.getFilter(): expression

**Parser usage sample:**
```typescript
import { FilterParser } from './filter/filter-parser.android'; // or .ios

const nativeFilter = FilterParser.parseJson(["all", ["has", "prop"]]);
const json = FilterParser.toJson(nativeFilter);
```

**Layer usage sample:**
```typescript
function doSetFilter() {
  this.map.getLayer('waterway').then((layer) => {
    layer.setFilter(["all", ["has", "prop"]]);
  }
}

function doGetFilter() {
  this.map.getLayer('waterway').then((layer) => {
    const filter = layer.getFilter();
    console.log(filter);
  }
}
```