### PR TITLE
Allow multiple click listeners on iOS

### DIFF
--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -1708,14 +1708,6 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                 theMap['mapTapHandler'] = MapTapHandlerImpl.initWithOwnerAndListenerForMap(new WeakRef(this), listener, theMap);
                 const tapGestureRecognizer = UITapGestureRecognizer.alloc().initWithTargetAction(theMap['mapTapHandler'], 'tap');
 
-                // cancel the default tap handler
-                for (let i = 0; i < theMap.gestureRecognizers.count; i++) {
-                    const recognizer: UIGestureRecognizer = theMap.gestureRecognizers.objectAtIndex(i);
-                    if (recognizer instanceof UITapGestureRecognizer) {
-                        tapGestureRecognizer.requireGestureRecognizerToFail(recognizer);
-                    }
-                }
-
                 theMap.addGestureRecognizer(tapGestureRecognizer);
 
                 resolve();


### PR DESCRIPTION
Fixes #22

This change allows to set multiple click listeners on iOS. I know there is a workaround by using `onMapEvent` function and `click` as event name to set multiple listeners for a specific layer, but it's not a solution if a user wants to listen to multiple layers on the same callback. So the user may want to implement his own click logic. I should mention that for some reason current implementation of `setOnMapClickListener` does not even work with 1 click listener on iOS, but this change will fix it too. I'm not sure if this should be done on Android too, so please let me know if it's the case.