### PR TITLE
fix: correctly implement padding

### DIFF
--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -2079,7 +2079,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                     .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.south, options.bounds.west))
                     .build();
 
-                const padding = 25,
+                const padding = options.padding !== undefined ? options.padding : 25,
                     animated = options.animated === undefined || options.animated,
                     durationMs = animated ? 1000 : 0;
 

--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -1914,12 +1914,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                 const animated = options.animated === undefined || options.animated;
 
                 // support defined padding
-                const padding: UIEdgeInsets = Mapbox.merge(options.padding === undefined ? {} : options.padding, {
-                    top: 25,
-                    left: 25,
-                    bottom: 25,
-                    right: 25
-                });
+                const padding: UIEdgeInsets =
+                    options.padding !== undefined ? { top: options.padding, left: options.padding, bottom: options.padding, right: options.padding } : { top: 25, left: 25, bottom: 25, right: 25 };
 
                 theMap.setVisibleCoordinateBoundsEdgePaddingAnimated(bounds, padding, animated);
                 resolve();


### PR DESCRIPTION
`setViewport()` was not implementing the `padding` parameter correctly. The parameter existed, but was never used properly and ended up always being set to 25. 