### PR TITLE
feat(android): Location component options

### DIFF
--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -574,7 +574,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                                 if (settings.showUserLocation) {
                                     this.requestFineLocationPermission()
                                         .then(() => {
-                                            this.showUserLocationMarker({});
+                                            this.showUserLocationMarker(settings.locationComponentOptions);
 
                                             // if we have a callback defined, call it.
 

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -2719,9 +2719,16 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
                 this.requestFineLocationPermission()
                     .then(() => {
-                        this.showUserLocationMarker({
-                            useDefaultLocationEngine: true
-                        });
+                        if (this._locationComponent) {
+                            this.changeUserLocationMarkerMode(
+                              options.renderMode || 'COMPASS',
+                              options.cameraMode || 'TRACKING',
+                            );
+                        } else {
+                            this.showUserLocationMarker({
+                                useDefaultLocationEngine: true
+                            });
+                        }
                     })
                     .catch((err) => {
                         console.error('Location permission denied. error:', err);
@@ -2840,13 +2847,13 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
             case 'TRACKING':
                 return modeRef.TRACKING;
 
-            case 'TRACK_COMPASS':
+            case 'TRACKING_COMPASS':
                 return modeRef.TRACKING_COMPASS;
 
             case 'TRACKING_GPS':
                 return modeRef.TRACKING_GPS;
 
-            case 'TRACK_GPS_NORTH':
+            case 'TRACKING_GPS_NORTH':
                 return modeRef.TRACKING_GPS_NORTH;
         }
     }
@@ -3092,26 +3099,37 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                     return;
                 }
 
-                if (Trace.isEnabled()) {
-                    CLog(CLogTypes.info, 'changeUserLocationMarkerMode(): current render mode is:', this._locationComponent.getRenderMode());
+                if (cameraModeString) {
+                    const cameraMode = this._stringToCameraMode(cameraModeString);
+                    if (Trace.isEnabled()) {
+                        CLog(CLogTypes.info, `Mapbox::changeUserLocationMarkerMode(): current camera mode is: ${this._locationComponent.getCameraMode()}`);
+                        CLog(CLogTypes.info, `Mapbox::changeUserLocationMarkerMode(): changing camera mode to: ${cameraMode}`);
+                    }
+
+                    this._locationComponent.setCameraMode(cameraMode);
+
+                    if (Trace.isEnabled()) {
+                        CLog(CLogTypes.info, `Mapbox::changeUserLocationMarkerMode(): new camera mode is: ${this._locationComponent.getCameraMode()}`);
+                    }
                 }
 
-                if (Trace.isEnabled()) {
-                    CLog(CLogTypes.info, "Mapbox::changeUserLocationMarkerMode(): changing renderMode to '" + renderModeString + "' cameraMode '" + cameraModeString + "'");
+                if (renderModeString) {
+                    const renderMode = this._stringToRenderMode(renderModeString);
+                    if (Trace.isEnabled()) {
+                        CLog(CLogTypes.info, `Mapbox::changeUserLocationMarkerMode(): current render mode is: ${this._locationComponent.getRenderMode()}`);
+                        CLog(CLogTypes.info, `Mapbox::changeUserLocationMarkerMode(): changing render mode to: '${renderMode}'`);
+                    }
+
+                    this._locationComponent.setRenderMode(renderMode);
+
+                    if (Trace.isEnabled()) {
+                        CLog(CLogTypes.info, 'changeUserLocationMarkerMode(): new render mode is:', this._locationComponent.getRenderMode());
+                    }
                 }
 
-                const cameraMode = this._stringToCameraMode(cameraModeString);
-                const renderMode = this._stringToRenderMode(renderModeString);
-
-                this._locationComponent.setCameraMode(cameraMode);
-                this._locationComponent.setRenderMode(renderMode);
-
-                if (Trace.isEnabled()) {
-                    CLog(CLogTypes.info, 'changeUserLocationMarkerMode(): new render mode is:', this._locationComponent.getRenderMode());
-                }
             } catch (ex) {
                 if (Trace.isEnabled()) {
-                    CLog(CLogTypes.info, 'Error in mapbox.showUserLocationMarker: ' + ex);
+                    CLog(CLogTypes.info, 'Error in mapbox.changeUserLocationMarkerMode: ' + ex);
                 }
                 reject(ex);
             }

--- a/src/mapbox.common.ts
+++ b/src/mapbox.common.ts
@@ -340,12 +340,13 @@ export interface GeoJSONSource extends Source {
 
 // ------------------------------------------------------------
 
-export type UserLocationCameraMode = 'NONE' | 'NONE_COMPASS' | 'NONE_GPS' | 'TRACKING' | 'TRACK_COMPASS' | 'TRACKING_GPS' | 'TRACK_GPS_NORTH';
+export type UserLocationCameraMode = 'NONE' | 'NONE_COMPASS' | 'NONE_GPS' | 'TRACKING' | 'TRACKING_COMPASS' | 'TRACKING_GPS' | 'TRACKING_GPS_NORTH';
 
 // ------------------------------------------------------------
 
 export interface TrackUserOptions {
-    mode: UserLocationCameraMode;
+    cameraMode: UserLocationCameraMode;
+    renderMode?: string;
     /**
      * iOS only, as Android is always animated. Default true (because of Android).
      */

--- a/src/mapbox.common.ts
+++ b/src/mapbox.common.ts
@@ -703,6 +703,7 @@ export abstract class MapboxCommon implements MapboxCommonApi {
         },
         zoomLevel: 0, // 0 (a big part of the world) to 20 (street level)
         showUserLocation: false, // true requires adding `NSLocationWhenInUseUsageDescription` or `NSLocationAlwaysUsageDescription` in the .plist
+        locationComponentOptions: {},
         hideLogo: false, // required for the 'starter' plan
         hideAttribution: true,
         hideCompass: false,
@@ -1075,6 +1076,12 @@ export const showUserLocationProperty = new Property<MapboxViewCommonBase, boole
 });
 showUserLocationProperty.register(MapboxViewCommonBase);
 
+export const locationComponentOptionsProperty = new Property<MapboxViewCommonBase, object>({
+    name: "locationComponentOptions",
+    defaultValue: MapboxCommon.defaults.locationComponentOptions,
+  });
+locationComponentOptionsProperty.register(MapboxViewCommonBase);
+
 export const hideLogoProperty = new Property<MapboxViewCommonBase, boolean>({
     name: 'hideLogo',
     defaultValue: MapboxCommon.defaults.hideLogo,
@@ -1189,6 +1196,10 @@ export abstract class MapboxViewBase extends MapboxViewCommonBase {
 
     [showUserLocationProperty.setNative](value: boolean) {
         this.config.showUserLocation = value;
+    }
+
+    [locationComponentOptionsProperty.setNative](value: boolean) {
+        this.config.locationComponentOptions = value || {};
     }
 
     [hideLogoProperty.setNative](value: boolean) {

--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -1281,14 +1281,14 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
             case 'TRACKING':
                 return MGLUserTrackingMode.Follow;
 
-            case 'TRACK_COMPASS':
+            case 'TRACKING_COMPASS':
                 return MGLUserTrackingMode.FollowWithHeading;
 
             case 'TRACKING_GPS':
                 // a reasonable approximation.
                 return MGLUserTrackingMode.Follow;
 
-            case 'TRACK_GPS_NORTH':
+            case 'TRACKING_GPS_NORTH':
                 return MGLUserTrackingMode.FollowWithCourse;
         }
     }
@@ -2527,7 +2527,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                     return;
                 }
 
-                theMap.setUserTrackingModeAnimated(_getTrackingMode(options.mode), options.animated !== false);
+                theMap.setUserTrackingModeAnimated(_getTrackingMode(options.cameraMode), options.animated !== false);
 
                 resolve();
             } catch (ex) {


### PR DESCRIPTION
I've had some changes sitting in a fork of `nativescript-mapbox` for quite a while. More may be incoming as I continue to work on an app that makes use of mapbox.

Location component options can now be passed to the component via XML as `locationComponentOptions` (Android only for now).

```js
locationComponentOptions: {
  accuracyColor: '#f35035',
  bearingTintColor: '#f35035',
  foregroundTintColor: '#f35035',
  foregroundStaleTintColor: '#3e3f3a',
  cameraMode: 'NONE',
  clickListener: this.handleLocationComponentClick,
},
```

I've also fixed the incorrectly named camera mode from `TRACK_COMPASS` to `TRACKING_COMPASS`. Removed camera `mode` attribute in place of `cameraMode` and `renderMode` and fixed the `trackUser` method to honour those attributes.