### PR TITLE
feat(android): return metadata, pixelRatio and type with offline region

### DIFF
--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -2101,7 +2101,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         });
     }
 
-    downloadOfflineRegion(options: DownloadOfflineRegionOptions): Promise<void> {
+    downloadOfflineRegion(options: DownloadOfflineRegionOptions): Promise<any> {
         return new Promise((resolve, reject) => {
             try {
                 const styleURL = this._getMapStyle(options.style);
@@ -2163,7 +2163,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                                         }
 
                                         if (status.isComplete()) {
-                                            resolve();
+                                            resolve(status);
                                         } else if (status.isRequiredResourceCountPrecise()) {
                                         }
                                     },

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -2896,7 +2896,11 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         const metadata = offlineRegion.getMetadata();
         const jsonStr = new java.lang.String(metadata, 'UTF-8');
         const jsonObj = new org.json.JSONObject((jsonStr as any) as string);
-        return jsonObj.getString('name');
+        try {
+            return jsonObj.getString('name');
+        } catch (error) {
+            return '';
+        }
     }
 
     _getRegionMetadata(offlineRegion: com.mapbox.mapboxsdk.offline.OfflineRegion) {

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -2220,7 +2220,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                                     const metadata = this._getRegionMetadata(offlineRegion);
 
                                     regions.push({
-                                        name,
+                                        id: offlineRegion.getID(),
+                                        name: name,
                                         style: offlineRegionDefinition.getStyleURL(),
                                         minZoom: offlineRegionDefinition.getMinZoom(),
                                         maxZoom: offlineRegionDefinition.getMaxZoom(),

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -2115,7 +2115,10 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
                 const offlineRegionDefinition = new com.mapbox.mapboxsdk.offline.OfflineTilePyramidRegionDefinition(styleURL, bounds, options.minZoom, options.maxZoom, retinaFactor);
 
-                const info = '{name:"' + options.name + '"}';
+                const info = {
+                    name: options.name,
+                    ...options.metadata
+                };
                 const infoStr = new java.lang.String(info);
                 const encodedMetadata = infoStr.getBytes();
 

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -2252,7 +2252,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     deleteOfflineRegion(options: DeleteOfflineRegionOptions): Promise<void> {
         return new Promise((resolve, reject) => {
             try {
-                if (!options || (!options.id || !options.name)) {
+                if (!options || (!options.id && !options.name)) {
                     reject("Pass in the 'id' or 'name' param");
                     return;
                 }

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -2119,7 +2119,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                     name: options.name,
                     ...options.metadata
                 };
-                const infoStr = new java.lang.String(info);
+                const infoStr = new java.lang.String(JSON.stringify(info));
                 const encodedMetadata = infoStr.getBytes();
 
                 if (!this._accessToken && !options.accessToken) {

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -2249,8 +2249,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     deleteOfflineRegion(options: DeleteOfflineRegionOptions): Promise<void> {
         return new Promise((resolve, reject) => {
             try {
-                if (!options || !options.name) {
-                    reject("Pass in the 'name' param");
+                if (!options || !options.id || !options.name) {
+                    reject("Pass in the 'id' or 'name' param");
                     return;
                 }
 
@@ -2265,8 +2265,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                             if (offlineRegions !== null) {
                                 for (let i = 0; i < offlineRegions.length; i++) {
                                     const offlineRegion = offlineRegions[i];
-                                    const name = this._getRegionName(offlineRegion);
-                                    if (name === options.name) {
+                                    let regionId = options.id ? offlineRegion.getID() : this._getRegionName(offlineRegion)
+                                    if (regionId === (options.id || options.name)) {
                                         found = true;
                                         offlineRegion.delete(
                                             new com.mapbox.mapboxsdk.offline.OfflineRegion.OfflineRegionDeleteCallback({
@@ -2291,7 +2291,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                 );
             } catch (ex) {
                 if (Trace.isEnabled()) {
-                    CLog(CLogTypes.info, 'Error in mapbox.listOfflineRegions: ' + ex);
+                    CLog(CLogTypes.info, 'Error in mapbox.deleteOfflineRegion: ' + ex);
                 }
                 reject(ex);
             }

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -2214,6 +2214,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                                     const name = this._getRegionName(offlineRegion);
                                     const offlineRegionDefinition = offlineRegion.getDefinition();
                                     const bounds = offlineRegionDefinition.getBounds();
+                                    const metadata = this._getRegionMetadata(offlineRegion);
 
                                     regions.push({
                                         name,
@@ -2225,7 +2226,10 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                                             east: bounds.getLonEast(),
                                             south: bounds.getLatSouth(),
                                             west: bounds.getLonWest()
-                                        }
+                                        },
+                                        metadata: metadata,
+                                        pixelRatio: offlineRegionDefinition.getPixelRatio(),
+                                        type: offlineRegionDefinition.getType(),
                                     });
                                 }
                             }
@@ -2889,6 +2893,13 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         const jsonStr = new java.lang.String(metadata, 'UTF-8');
         const jsonObj = new org.json.JSONObject((jsonStr as any) as string);
         return jsonObj.getString('name');
+    }
+
+    _getRegionMetadata(offlineRegion: com.mapbox.mapboxsdk.offline.OfflineRegion) {
+        const metadata = offlineRegion.getMetadata();
+        const jsonStr = new java.lang.String(metadata, "UTF-8");
+        const jsonObj = new org.json.JSONObject((jsonStr as any) as string);
+        return JSON.parse(jsonObj.toString());
     }
 
     /**

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -2249,7 +2249,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     deleteOfflineRegion(options: DeleteOfflineRegionOptions): Promise<void> {
         return new Promise((resolve, reject) => {
             try {
-                if (!options || !options.id || !options.name) {
+                if (!options || (!options.id || !options.name)) {
                     reject("Pass in the 'id' or 'name' param");
                     return;
                 }

--- a/src/mapbox.common.ts
+++ b/src/mapbox.common.ts
@@ -364,6 +364,9 @@ export interface OfflineRegion {
     minZoom: number;
     maxZoom: number;
     style: MapStyle;
+    metadata?: any;
+    pixelRatio?: any;
+    type?: any;
 }
 
 // ------------------------------------------------------------

--- a/src/mapbox.common.ts
+++ b/src/mapbox.common.ts
@@ -225,9 +225,14 @@ export interface SetViewportOptions {
 
 export interface DeleteOfflineRegionOptions {
     /**
+     * The id of the offline region to delete.
+     */
+    id?: string;
+
+    /**
      * The name of the offline region to delete.
      */
-    name: string;
+    name?: string;
 }
 
 // ------------------------------------------------------------

--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -2048,7 +2048,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     deleteOfflineRegion(options: DeleteOfflineRegionOptions): Promise<void> {
         return new Promise((resolve, reject) => {
             try {
-                if (!options || !options.id || !options.name) {
+                if (!options || (!options.id || !options.name)) {
                     reject("Pass in the 'id' or 'name' param");
                     return;
                 }

--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -2048,8 +2048,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     deleteOfflineRegion(options: DeleteOfflineRegionOptions): Promise<void> {
         return new Promise((resolve, reject) => {
             try {
-                if (!options || !options.name) {
-                    reject("Pass in the 'name' param");
+                if (!options || !options.id || !options.name) {
+                    reject("Pass in the 'id' or 'name' param");
                     return;
                 }
 
@@ -2058,8 +2058,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                 for (let i = 0; i < packs.count; i++) {
                     const pack = packs.objectAtIndex(i);
                     const userInfo = NSKeyedUnarchiver.unarchiveObjectWithData(pack.context);
-                    const name = userInfo.objectForKey('name');
-                    if (name === options.name) {
+                    const regionId = options.id ? userInfo.objectForKey('id') : userInfo.objectForKey('name');
+                    if (regionId === (options.id || options.name)) {
                         found = true;
                         MGLOfflineStorage.sharedOfflineStorage.removePackWithCompletionHandler(pack, (error: NSError) => {
                             if (error) {

--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -2048,7 +2048,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     deleteOfflineRegion(options: DeleteOfflineRegionOptions): Promise<void> {
         return new Promise((resolve, reject) => {
             try {
-                if (!options || (!options.id || !options.name)) {
+                if (!options || (!options.id && !options.name)) {
                     reject("Pass in the 'id' or 'name' param");
                     return;
                 }


### PR DESCRIPTION
`downloadOfflineRegion()` now supports setting `metadata` as a JSON object.

`listOfflineRegions()` will now include: `metadata`, `pixelRatio` and `type`

 I've left the `name` attribute untouched for backwards compatibility (but we should probably remove it). `name` is just a shortcut to set `metadata.name`.

Offline regions can also be deleted by the `id` which is set via `metadata.id`.