### PR TITLE
feat(lineMetrics): added source property `lineMetrics`

### DIFF
--- a/src/ui-mapbox/common.ts
+++ b/src/ui-mapbox/common.ts
@@ -342,6 +342,7 @@ export interface GeoJSONSource extends Source {
     data?: any;
     minzoom?: number;
     maxzoom?: number;
+    lineMetrics?: boolean;
     cluster?: {
         radius;
         maxZoom;

--- a/src/ui-mapbox/index.android.ts
+++ b/src/ui-mapbox/index.android.ts
@@ -2505,6 +2505,11 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                         if (options.maxzoom) {
                             geojsonOptions.withMaxZoom(options.maxzoom);
                         }
+
+                        if (options.lineMetrics !== undefined) {
+                            geojsonOptions.withLineMetrics(options.lineMetrics);
+                        }
+
                         if (options.cluster) {
                             geojsonOptions
                                 .withCluster(true)

--- a/src/ui-mapbox/index.ios.ts
+++ b/src/ui-mapbox/index.ios.ts
@@ -2773,7 +2773,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                         if (options.maxzoom !== undefined) {
                             sourceOptions[MGLShapeSourceOptionMaximumZoomLevel] = options.maxzoom;
                         }
-
+                        if (options.lineMetrics !== undefined) {
+                            sourceOptions[MGLShapeSourceOptionLineDistanceMetrics] = options.lineMetrics;
+                        }
                         if (options.cluster) {
                             sourceOptions[MGLShapeSourceOptionClustered] = true;
                             sourceOptions[MGLShapeSourceOptionClusterRadius] = options.cluster.radius || 40;


### PR DESCRIPTION
In order to use line gradients, the option `lineMetrics` is needed. On iOS side, this is achieved by setting MGLShapeSourceOptionLineDistanceMetrics(https://mapbox.github.io/mapbox-gl-native/macos/0.12.0/Other%20Constants.html#/c:@MGLShapeSourceOptionLineDistanceMetrics) and on Android it can be set with `withLineMetrics` on the `GeoJsonOptions`. The option `lineMetrics` was added to the `GeoJSONSource` API object and is used in the `addSource(...)` methods on iOS and Android as described above.