### PR TITLE
feat(layer type): added property `type` to layer class that returns the GeoJSON layer type

### DIFF
--- a/src/ui-mapbox/common.ts
+++ b/src/ui-mapbox/common.ts
@@ -703,6 +703,8 @@ export interface MapboxApi {
 
     removeImage(imageId: string, nativeMap?: any): Promise<void>;
     project(data: LatLng): { x: number; y: number };
+
+    projectBack(point: { x: number, y: number }): LatLng;
 }
 
 // ------------------------------------------------------------
@@ -1060,6 +1062,9 @@ export abstract class MapboxViewCommonBase extends ContentView implements Mapbox
     }
     project(data: LatLng) {
         return this.mapbox && this.mapbox.project(data);
+    }
+    projectBack(screenCoordinate: { x: number, y: number }): LatLng {
+        return this.mapbox && this.mapbox.projectBack(screenCoordinate);
     }
 }
 

--- a/src/ui-mapbox/common.ts
+++ b/src/ui-mapbox/common.ts
@@ -263,11 +263,19 @@ export interface AddGeoJsonClusteredOptions {
     clusters?: MapboxCluster[];
 }
 
+// ------------------------------------------------------------
+
+export type LayerType = "fill" | "line" | "symbol" | "circle" | "heatmap" | "fill-extrusion" | "raster" | "hillshade" | "background" | "sky"
+
+export type SupportedLayerType = LayerType & ("line" | "circle" | "fill" | "symbol" | "raster")
+
+// ------------------------------------------------------------
+
 export interface AddLayerOptions {
     id: string;
     source: string;
     sourceLayer: string;
-    type: string;
+    type: SupportedLayerType;
 
     /**
      * 'circle' paint properties
@@ -553,6 +561,7 @@ export interface LayerCommon {
     getNativeInstance(): any;
     setFilter(filter: any[]): void;
     getFilter(): any[];
+    type(): LayerType;
 }
 
 // ------------------------------------------------------------

--- a/src/ui-mapbox/index.android.ts
+++ b/src/ui-mapbox/index.android.ts
@@ -3391,4 +3391,12 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         const screenLocation = this._mapboxMapInstance.getProjection().toScreenLocation(mapboxPoint);
         return { x: Utils.layout.toDeviceIndependentPixels(screenLocation.x), y: Utils.layout.toDeviceIndependentPixels(screenLocation.y) };
     }
+    projectBack(screenCoordinate: { x: number, y: number }): LatLng {
+        const pointf = new android.graphics.PointF(screenCoordinate.x, screenCoordinate.y);
+        const coordinate = this._mapboxMapInstance.getProjection().fromScreenLocation(pointf);
+        return {
+            lat: coordinate.getLatitude(),
+            lng: coordinate.getLongitude()
+        }
+    }
 }

--- a/src/ui-mapbox/index.d.ts
+++ b/src/ui-mapbox/index.d.ts
@@ -97,4 +97,5 @@ export declare class Mapbox extends MapboxCommon implements MapboxApi {
         x: number;
         y: number;
     };
+    projectBack(screenCoordinate: { x: number, y: number }): LatLng;
 }

--- a/src/ui-mapbox/index.ios.ts
+++ b/src/ui-mapbox/index.ios.ts
@@ -3159,6 +3159,19 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         const { x, y } = theMap.convertCoordinateToPointToView({ latitude: data.lat, longitude: data.lng }, theMap);
         return { x, y };
     }
+
+    projectBack(screenCoordinate: { x: number, y: number }): LatLng {
+        const theMap: MGLMapView = this._mapboxViewInstance;
+        const cgPoint = {
+            x: screenCoordinate.x,
+            y: screenCoordinate.y
+        }
+        const coordinate = theMap.convertPointToCoordinateFromView(cgPoint, theMap);
+        return {
+            lat: coordinate.latitude,
+            lng: coordinate.longitude
+        }
+    }
 }
 
 const _addObserver = (eventName, callback) => NSNotificationCenter.defaultCenter.addObserverForNameObjectQueueUsingBlock(eventName, null, NSOperationQueue.mainQueue, callback);

--- a/src/ui-mapbox/layers/layer-factory.android.ts
+++ b/src/ui-mapbox/layers/layer-factory.android.ts
@@ -1,4 +1,4 @@
-import { LayerCommon } from '../common';
+import { LayerCommon, LayerType } from "../common"
 import { ExpressionParser } from '../expression/expression-parser';
 import { PropertyParser } from './parser/property-parser';
 
@@ -42,6 +42,40 @@ export class Layer implements LayerCommon {
 
     public getProperty(name: string): any {
         return PropertyParser.propertyValueFromLayer(this.instance, name);
+    }
+
+    public type(): LayerType {
+        if (this.instance instanceof com.mapbox.mapboxsdk.style.layers.FillLayer) {
+            return "fill"
+        }
+        if (this.instance instanceof com.mapbox.mapboxsdk.style.layers.LineLayer) {
+            return "line"
+        }
+        if (this.instance instanceof com.mapbox.mapboxsdk.style.layers.SymbolLayer) {
+            return "symbol"
+        }
+        if (this.instance instanceof com.mapbox.mapboxsdk.style.layers.CircleLayer) {
+            return "circle"
+        }
+        if (this.instance instanceof com.mapbox.mapboxsdk.style.layers.HeatmapLayer) {
+            return "heatmap"
+        }
+        if (this.instance instanceof com.mapbox.mapboxsdk.style.layers.FillExtrusionLayer) {
+            return "fill-extrusion"
+        }
+        if (this.instance instanceof com.mapbox.mapboxsdk.style.layers.RasterLayer) {
+            return "raster"
+        }
+        if (this.instance instanceof com.mapbox.mapboxsdk.style.layers.HillshadeLayer) {
+            return "hillshade"
+        }
+        if (this.instance instanceof com.mapbox.mapboxsdk.style.layers.BackgroundLayer) {
+            return "background"
+        }
+
+        // there is no sky layer in the Android Mapbox SDK
+
+        return null;
     }
 }
 

--- a/src/ui-mapbox/layers/layer-factory.d.ts
+++ b/src/ui-mapbox/layers/layer-factory.d.ts
@@ -1,4 +1,4 @@
-import { LayerCommon } from '../common';
+import { LayerCommon, LayerType } from "../common"
 
 declare class LayerFactory {
     static createLayer(style, source): Promise<LayerCommon>;
@@ -16,4 +16,5 @@ export declare class Layer implements LayerCommon {
     getFilter(): any[];
     setProperty(name: string, value: any): void;
     getProperty(name: string): any;
+    type(): LayerType;
 }

--- a/src/ui-mapbox/layers/layer-factory.ios.ts
+++ b/src/ui-mapbox/layers/layer-factory.ios.ts
@@ -1,4 +1,4 @@
-import { LayerCommon } from '../common';
+import { LayerCommon, LayerType } from "../common"
 import { ExpressionParser } from '../expression/expression-parser';
 import { PropertyParser } from './parser/property-parser';
 
@@ -53,11 +53,45 @@ export class LayerFactory {
 
 export class Layer implements LayerCommon {
     public id: string;
-    private instance;
+    private instance: MGLStyleLayer;
 
-    constructor(instance) {
+    constructor(instance: MGLStyleLayer) {
         this.instance = instance;
         this.id = instance.identifier;
+    }
+
+    type(): LayerType {
+        if (this.instance instanceof MGLFillStyleLayer) {
+            return "fill"
+        }
+        if (this.instance instanceof MGLLineStyleLayer) {
+            return "line"
+        }
+        if (this.instance instanceof MGLSymbolStyleLayer) {
+            return "symbol"
+        }
+        if (this.instance instanceof MGLCircleStyleLayer) {
+            return "circle"
+        }
+        if (this.instance instanceof MGLHeatmapStyleLayer) {
+            return "heatmap"
+        }
+        if (this.instance instanceof MGLFillExtrusionStyleLayer) {
+            return "fill-extrusion"
+        }
+        if (this.instance instanceof MGLRasterStyleLayer) {
+            return "raster"
+        }
+        if (this.instance instanceof MGLHillshadeStyleLayer) {
+            return "hillshade"
+        }
+        if (this.instance instanceof MGLBackgroundStyleLayer) {
+            return "background"
+        }
+
+        // there is no sky layer in the Mapbox iOS SDK
+
+        return null;
     }
 
     visibility(): boolean {


### PR DESCRIPTION
In order to get more information about the type of a layer (e.g. obtained by calling `getLayers`), the GeoJSON layer type was added as property to the layer class. This is for example helpful to find the first symbol layer to add a polyline layer under all map annotations.