### PR TITLE
fix(`updateSource`): `updateSource` method was missing in the API

### DIFF
--- a/src/ui-mapbox/common.ts
+++ b/src/ui-mapbox/common.ts
@@ -629,6 +629,7 @@ export interface MapboxApi {
     trackUser(options: TrackUserOptions, nativeMap?: any): Promise<void>;
 
     addSource(id: string, options: AddSourceOptions, nativeMapView?: any): Promise<any>;
+
     updateSource(id: string, options: UpdateSourceOptions, nativeMapView?: any): Promise<any>;
 
     removeSource(id: string, nativeMap?: any): Promise<any>;
@@ -828,6 +829,8 @@ export interface MapboxViewApi {
     forceUserLocationUpdate(location): void;
 
     addSource(id: string, options: AddSourceOptions): Promise<any>;
+
+    updateSource(id: string, options: UpdateSourceOptions): Promise<any>;
 
     removeSource(id: string, nativeMap?: any): Promise<any>;
 


### PR DESCRIPTION
Added `updateSource` method that was already implemented to the API definition.