### PR TITLE
Fix issue #88 [Call to getLayer() throws the error "TypeError: Cannot read property 'identifier' of null" [iOS only]]

### DIFF
--- a/src/ui-mapbox/index.ios.ts
+++ b/src/ui-mapbox/index.ios.ts
@@ -3119,7 +3119,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
                 const layer = theMap.style.layerWithIdentifier(name);
 
-                resolve(new Layer(layer));
+                resolve(layer ? new Layer(layer) : null);
             } catch (ex) {
                 if (Trace.isEnabled()) {
                     CLog(CLogTypes.info, 'Error in mapbox.getLayer: ' + ex);


### PR DESCRIPTION
Fix issue [#88](https://github.com/nativescript-community/ui-mapbox/issues/88)