### PR TITLE
Upgrade iOS Mapbox API to 6.4.1

### DIFF
--- a/packages/ui-mapbox/platforms/ios/Podfile
+++ b/packages/ui-mapbox/platforms/ios/Podfile
@@ -1,3 +1,3 @@
 platform :ios, '13.0'
 
-pod 'Mapbox-iOS-SDK', '~> 5.1.1'
+pod 'Mapbox-iOS-SDK', '~> 6.4.1'


### PR DESCRIPTION
Propose upgrade of the Mapbox SDK to the last version that seems to be compatible with this plugin implemented (see #92 as a follow up).

Currently, the map view crashes within all iOS emulators I had the chance to try it with. After upgrading it to the given version, it works.

the pin to the current version was done in https://github.com/nativescript-community/ui-mapbox/commit/3aa8196259497799a2f8c1019b0210b9834bb2cf  but I couldn't find any reason for it.

Notice: the demo-ng app will fail to start as currently, it has `  "@nativescript/ios": "6.5.4" ` in its dependencies. After upgrading it (to 8.3.3), the demo runs fine.