### PR TITLE
tap handler fix

### DIFF
--- a/src/ui-mapbox/index.ios.ts
+++ b/src/ui-mapbox/index.ios.ts
@@ -1911,7 +1911,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                 const tapGestureRecognizer = UITapGestureRecognizer.alloc().initWithTargetAction(theMap['mapTapHandler'], 'tap');
                 for (let i = 0; i < theMap.gestureRecognizers.count; i++) {
                     const recognizer = theMap.gestureRecognizers.objectAtIndex(i);
-                    if (recognizer instanceof UIPanGestureRecognizer) {
+                    if (recognizer instanceof UITapGestureRecognizer) {
                         recognizer.addTargetAction(theMap['mapTapHandler'], 'tap');
                         break;
                     }

--- a/src/ui-mapbox/index.ios.ts
+++ b/src/ui-mapbox/index.ios.ts
@@ -1907,20 +1907,17 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                     return;
                 }
 
-                // adding the tap handler to the map object so it's not garbage collected.
                 theMap['mapTapHandler'] = MapTapHandlerImpl.initWithOwnerAndListenerForMap(new WeakRef(this), listener, theMap);
                 const tapGestureRecognizer = UITapGestureRecognizer.alloc().initWithTargetAction(theMap['mapTapHandler'], 'tap');
-
-                // cancel the default tap handler
                 for (let i = 0; i < theMap.gestureRecognizers.count; i++) {
-                    const recognizer: UIGestureRecognizer = theMap.gestureRecognizers.objectAtIndex(i);
-                    if (recognizer instanceof UITapGestureRecognizer) {
-                        tapGestureRecognizer.requireGestureRecognizerToFail(recognizer);
+                    const recognizer = theMap.gestureRecognizers.objectAtIndex(i);
+                    if (recognizer instanceof UIPanGestureRecognizer) {
+                        recognizer.addTargetAction(theMap['mapTapHandler'], 'tap');
+                        break;
                     }
                 }
 
                 theMap.addGestureRecognizer(tapGestureRecognizer);
-
                 resolve();
             } catch (ex) {
                 if (Trace.isEnabled()) {


### PR DESCRIPTION
tap handler now works as it should in ios.  The same is required for the long press, but I need to find out the handler name first.