### PR TITLE
Another attempt to fix click listener issue on iOS

### DIFF
--- a/src/ui-mapbox/index.ios.ts
+++ b/src/ui-mapbox/index.ios.ts
@@ -1909,13 +1909,6 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
                 theMap['mapTapHandler'] = MapTapHandlerImpl.initWithOwnerAndListenerForMap(new WeakRef(this), listener, theMap);
                 const tapGestureRecognizer = UITapGestureRecognizer.alloc().initWithTargetAction(theMap['mapTapHandler'], 'tap');
-                for (let i = 0; i < theMap.gestureRecognizers.count; i++) {
-                    const recognizer = theMap.gestureRecognizers.objectAtIndex(i);
-                    if (recognizer instanceof UITapGestureRecognizer) {
-                        recognizer.addTargetAction(theMap['mapTapHandler'], 'tap');
-                        break;
-                    }
-                }
 
                 theMap.addGestureRecognizer(tapGestureRecognizer);
                 resolve();


### PR DESCRIPTION
Previously I sent a PR which is referenced as fixed with [another commit](https://github.com/nativescript-community/ui-mapbox/pull/27#issuecomment-1008447881), But the changes are not still applied to the latest version of plugin after about 2 years. So here is another PR, maybe there is another reason that this block of code still exists?

This PR fixes #22 