### PR TITLE
feat: extend options to position controls that overlay the map

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,11 @@ All currently supported options for your XML based map are (__don't__ use other 
 |`zoomLevel`|0|0-20
 |`showUserLocation `|false|Requires location permissions on Android which you can remove from `AndroidManifest.xml` if you don't need them
 |`hideCompass `|false|Don't show the compass in the top right corner during rotation of the map
+|`compassPosition`|ControlPosition.TOP_RIGHT|Corner in which to position the compass
 |`hideLogo`|false|Mapbox requires `false` if you're on a free plan
+|`logoPosition`|ControlPosition.BOTTOM_LEFT|Corner in which to position the Mapbox logo
 |`hideAttribution `|true|Mapbox requires `false` if you're on a free plan
+|`attributionPosition`|ControlPosition.BOTTOM_LEFT|Corner in which to position the attribution link
 |`disableZoom`|false|Don't allow the user to zoom in or out (pinch and double-tap)
 |`disableRotation`|false|Don't allow the user to rotate the map (two finger gesture)
 |`disableScroll`|false|Don't allow the user to move the center of the map (one finger drag)

--- a/src/ui-mapbox/index.android.ts
+++ b/src/ui-mapbox/index.android.ts
@@ -17,6 +17,7 @@ import {
     AnimateCameraOptions,
     CLog,
     CLogTypes,
+    ControlPosition,
     DeleteOfflineRegionOptions,
     DownloadOfflineRegionOptions,
     Feature,
@@ -126,7 +127,7 @@ export class MapboxView extends MapboxViewBase {
 
     private nativeMapView: any; // com.mapbox.mapboxsdk.maps.MapView
 
-    private settings: any = null;
+    private settings: ShowOptions = null;
 
     // whether or not the view has already been initialized.
     // see initNativeView()
@@ -144,7 +145,7 @@ export class MapboxView extends MapboxViewBase {
     /**
      * programmatically include settings
      */
-    setConfig(settings: any) {
+    setConfig(settings: ShowOptions) {
         // zoom level is not applied unless center is set
 
         if (settings.zoomLevel && !settings.center) {
@@ -170,7 +171,7 @@ export class MapboxView extends MapboxViewBase {
      *
      * @see Mapbox
      */
-    public getMapboxApi(): any {
+    public getMapboxApi() {
         return this.mapbox;
     }
 
@@ -2900,15 +2901,18 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
      * @link https://docs.mapbox.com/android/api/map-sdk/7.1.2/com/mapbox/mapboxsdk/maps/MapboxMapOptions.html
      */
 
-    _getMapboxMapOptions(settings) {
+    _getMapboxMapOptions(settings: ShowOptions) {
         const mapboxMapOptions = new com.mapbox.mapboxsdk.maps.MapboxMapOptions()
             .compassEnabled(!settings.hideCompass)
+            .compassGravity(Mapbox.mapPositionToGravity(settings.compassPosition))
             .rotateGesturesEnabled(!settings.disableRotation)
             .scrollGesturesEnabled(!settings.disableScroll)
             .tiltGesturesEnabled(!settings.disableTilt)
             .zoomGesturesEnabled(!settings.disableZoom)
             .attributionEnabled(!settings.hideAttribution)
-            .logoEnabled(!settings.hideLogo);
+            .attributionGravity(Mapbox.mapPositionToGravity(settings.attributionPosition))
+            .logoEnabled(!settings.hideLogo)
+            .logoGravity(Mapbox.mapPositionToGravity(settings.logoPosition));
 
         // zoomlevel is not applied unless center is set
         if (settings.zoomLevel && !settings.center) {
@@ -2927,6 +2931,19 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         }
 
         return mapboxMapOptions;
+    }
+
+    private static mapPositionToGravity(position: ControlPosition) {
+        switch (position) {
+            case ControlPosition.TOP_LEFT:
+                return android.view.Gravity.TOP | android.view.Gravity.START;
+            case ControlPosition.TOP_RIGHT:
+                return android.view.Gravity.TOP | android.view.Gravity.END;
+            case ControlPosition.BOTTOM_LEFT:
+                return android.view.Gravity.BOTTOM | android.view.Gravity.START;
+            case ControlPosition.BOTTOM_RIGHT:
+                return android.view.Gravity.BOTTOM | android.view.Gravity.END;
+        }
     }
 
     /**

--- a/src/ui-mapbox/index.ios.ts
+++ b/src/ui-mapbox/index.ios.ts
@@ -8,6 +8,7 @@ import {
     AnimateCameraOptions,
     CLog,
     CLogTypes,
+    ControlPosition,
     DeleteOfflineRegionOptions,
     DownloadOfflineRegionOptions,
     Feature,
@@ -517,10 +518,13 @@ export * from './common';
 let _markers = [];
 const _markerIconDownloadCache = [];
 
-const _setMapboxMapOptions = (mapView: MGLMapView, settings) => {
+const _setMapboxMapOptions = (mapView: MGLMapView, settings: ShowOptions) => {
     mapView.logoView.hidden = settings.hideLogo;
+    mapView.logoViewPosition = _mapControlPositionToOrnamentPosition(settings.logoPosition);
     mapView.attributionButton.hidden = settings.hideAttribution;
+    mapView.attributionButtonPosition = _mapControlPositionToOrnamentPosition(settings.attributionPosition);
     mapView.compassView.hidden = settings.hideCompass;
+    mapView.compassViewPosition = _mapControlPositionToOrnamentPosition(settings.compassPosition);
     mapView.rotateEnabled = !settings.disableRotation;
     mapView.scrollEnabled = !settings.disableScroll;
     mapView.zoomEnabled = !settings.disableZoom;
@@ -536,6 +540,19 @@ const _setMapboxMapOptions = (mapView: MGLMapView, settings) => {
     mapView.showsUserLocation = settings.showUserLocation;
 
     mapView.autoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
+};
+
+const _mapControlPositionToOrnamentPosition = (position: ControlPosition) => {
+    switch (position) {
+        case ControlPosition.TOP_LEFT:
+            return MGLOrnamentPosition.TopLeft;
+        case ControlPosition.TOP_RIGHT:
+            return MGLOrnamentPosition.TopRight;
+        case ControlPosition.BOTTOM_LEFT:
+            return MGLOrnamentPosition.BottomLeft;
+        case ControlPosition.BOTTOM_RIGHT:
+            return MGLOrnamentPosition.BottomRight;
+    }
 };
 
 const _getMapStyle = (input: any): NSURL => {


### PR DESCRIPTION
Allows each of logo, attribution, and the compass to be positioned in any corner.

### Example screenshots

<details><summary>Default layout</summary>
<p>

The bug on iOS where the logo and attribution icon overlay is existing behaviour. 
An Android the attribution has 92 of left margin so that it doesn't overlap, this applies regardless of whether the logo is in the same position.
This could be fixed by further extending the settings to allow margins to be controlled.

iOS ![Simulator Screenshot - iPhone 15 Pro Max - 2023-12-18 at 16 32 23](https://github.com/nativescript-community/ui-mapbox/assets/964928/980cca18-ee5c-4f07-887d-c41d5a0e8979)
Android ![Screenshot_1702888016](https://github.com/nativescript-community/ui-mapbox/assets/964928/c6135a1a-fb86-4b7f-b9ba-cb73534bfff8)

</p>
</details> 

<details><summary>Alternative layout 1</summary>
<p>

iOS ![Simulator Screenshot - iPhone 15 Pro Max - 2023-12-18 at 16 26 02](https://github.com/nativescript-community/ui-mapbox/assets/964928/3e9f5614-efbe-43bd-a86b-557cf4c163d1)
Android ![Screenshot_1702887988](https://github.com/nativescript-community/ui-mapbox/assets/964928/9a41b7ad-4374-400b-8172-cac54425d8ab)

</p>
</details>

<details><summary>Alternative layout 2</summary>
<p>

iOS ![Simulator Screenshot - iPhone 15 Pro Max - 2023-12-18 at 16 33 20](https://github.com/nativescript-community/ui-mapbox/assets/964928/ef632ad4-8403-44b1-9541-f78f9b3f3e4e)
Android ![Screenshot_1702888439](https://github.com/nativescript-community/ui-mapbox/assets/964928/641d7daf-9d02-4d45-b337-3cf72adcb266)

</p>
</details>