### PR TITLE
Fix Android/IOS annotation layer ordering for markers, polylines and polygons

### DIFF
--- a/packages/ui-mapbox/platforms/ios/src/MapboxBridge.swift
+++ b/packages/ui-mapbox/platforms/ios/src/MapboxBridge.swift
@@ -95,6 +95,8 @@ public class MapboxBridge: NSObject {
     public func postEvent(_ event: String)  {
         NotificationCenter.default.post(name: Notification.Name(event), object: self.mapView)
     }
+
+    public static let MARKER_LAYER_ID = "mapbox-ios-markers"
     
     // Notification constants
     public static let MapLoadedNotification = "MapboxBridgeMapLoaded"
@@ -203,6 +205,8 @@ public class MapboxBridge: NSObject {
         
         // Register this bridge for the created MapView
         MapboxBridge.registerBridge(self, for: mv)
+
+        pointAnnotationManager = mv.annotations.makePointAnnotationManager(id: MapboxBridge.MARKER_LAYER_ID)
         let defaultPinImage =  UIImage(named: "default_pin")
         if (defaultPinImage != nil) {
             self.defaultPinImageHeight = defaultPinImage!.size.height
@@ -445,7 +449,7 @@ public class MapboxBridge: NSObject {
         guard let markers = try? JSONSerialization.jsonObject(with: data, options: []) as! [NSDictionary] else { return }
         
         if pointAnnotationManager == nil {
-            pointAnnotationManager = mv.annotations.makePointAnnotationManager()
+            pointAnnotationManager = mv.annotations.makePointAnnotationManager(id: MapboxBridge.MARKER_LAYER_ID)
         }
         guard let manager = pointAnnotationManager else { return }
         
@@ -935,7 +939,10 @@ public class MapboxBridge: NSObject {
         
         
         if polylineAnnotationManager == nil {
-            polylineAnnotationManager = mv.annotations.makePolylineAnnotationManager()
+            polylineAnnotationManager = mv.annotations.makePolylineAnnotationManager(
+                id: "mapbox-ios-polylines",
+                layerPosition: .below(MapboxBridge.MARKER_LAYER_ID)
+            )
         }
         guard let manager = polylineAnnotationManager else { return false }
         var annotation = PolylineAnnotation(id: id, lineCoordinates: ccoords)
@@ -1139,7 +1146,10 @@ public class MapboxBridge: NSObject {
         
         
         if polygonAnnotationManager == nil {
-            polygonAnnotationManager = mv.annotations.makePolygonAnnotationManager()
+            polygonAnnotationManager = mv.annotations.makePolygonAnnotationManager(
+                id: "mapbox-ios-polygons",
+                layerPosition: .below(MapboxBridge.MARKER_LAYER_ID)
+            )
         }
         guard let manager = polygonAnnotationManager else { return false }
         let polygon = Polygon(outerRing: .init(coordinates: ccoords))
@@ -1162,7 +1172,10 @@ public class MapboxBridge: NSObject {
             
             if (strokeOpacity != nil || strokeWidth != nil){
                 if polygonOutlineAnnotationManager == nil {
-                    polygonOutlineAnnotationManager = mv.annotations.makePolylineAnnotationManager()
+                    polygonOutlineAnnotationManager = mv.annotations.makePolylineAnnotationManager(
+                        id: "mapbox-ios-polygon-outlines",
+                        layerPosition: .below(MapboxBridge.MARKER_LAYER_ID)
+                    )
                 }
                 var outline = PolylineAnnotation(id: id, lineCoordinates: ccoords)
                 if (strokeColor != nil) {

--- a/packages/ui-mapbox/platforms/ios/src/MapboxBridge.swift
+++ b/packages/ui-mapbox/platforms/ios/src/MapboxBridge.swift
@@ -97,6 +97,9 @@ public class MapboxBridge: NSObject {
     }
 
     public static let MARKER_LAYER_ID = "mapbox-ios-markers"
+    public static let POLYLINE_LAYER_ID = "mapbox-ios-polylines"
+    public static let POLYGON_LAYER_ID = "mapbox-ios-polygons"
+    public static let POLYGON_OUTLINE_LAYER_ID = "mapbox-ios-polygon-outlines"
     
     // Notification constants
     public static let MapLoadedNotification = "MapboxBridgeMapLoaded"
@@ -170,6 +173,16 @@ public class MapboxBridge: NSObject {
         return MapboxBridge.bridgeTable.object(forKey: mapView) as? MapboxBridge
     }
     
+    private func ensurePointAnnotationManager(for mapView: MapView) -> PointAnnotationManager {
+        if let manager = pointAnnotationManager {
+            return manager
+        }
+        
+        let manager = mapView.annotations.makePointAnnotationManager(id: MapboxBridge.MARKER_LAYER_ID)
+        pointAnnotationManager = manager
+        return manager
+    }
+    
     @objc  public  func getMapView() -> MapView? {
         return mapView
     }
@@ -205,8 +218,7 @@ public class MapboxBridge: NSObject {
         
         // Register this bridge for the created MapView
         MapboxBridge.registerBridge(self, for: mv)
-
-        pointAnnotationManager = mv.annotations.makePointAnnotationManager(id: MapboxBridge.MARKER_LAYER_ID)
+        _ = ensurePointAnnotationManager(for: mv)
         let defaultPinImage =  UIImage(named: "default_pin")
         if (defaultPinImage != nil) {
             self.defaultPinImageHeight = defaultPinImage!.size.height
@@ -448,10 +460,7 @@ public class MapboxBridge: NSObject {
         guard let data = markersJSON.data(using: .utf8) else { return }
         guard let markers = try? JSONSerialization.jsonObject(with: data, options: []) as! [NSDictionary] else { return }
         
-        if pointAnnotationManager == nil {
-            pointAnnotationManager = mv.annotations.makePointAnnotationManager(id: MapboxBridge.MARKER_LAYER_ID)
-        }
-        guard let manager = pointAnnotationManager else { return }
+        let manager = ensurePointAnnotationManager(for: mv)
         
         var current = manager.annotations
         var additions: [PointAnnotation] = []
@@ -938,9 +947,10 @@ public class MapboxBridge: NSObject {
         }
         
         
+        _ = ensurePointAnnotationManager(for: mv)
         if polylineAnnotationManager == nil {
             polylineAnnotationManager = mv.annotations.makePolylineAnnotationManager(
-                id: "mapbox-ios-polylines",
+                id: MapboxBridge.POLYLINE_LAYER_ID,
                 layerPosition: .below(MapboxBridge.MARKER_LAYER_ID)
             )
         }
@@ -1145,9 +1155,10 @@ public class MapboxBridge: NSObject {
         }
         
         
+        _ = ensurePointAnnotationManager(for: mv)
         if polygonAnnotationManager == nil {
             polygonAnnotationManager = mv.annotations.makePolygonAnnotationManager(
-                id: "mapbox-ios-polygons",
+                id: MapboxBridge.POLYGON_LAYER_ID,
                 layerPosition: .below(MapboxBridge.MARKER_LAYER_ID)
             )
         }
@@ -1173,7 +1184,7 @@ public class MapboxBridge: NSObject {
             if (strokeOpacity != nil || strokeWidth != nil){
                 if polygonOutlineAnnotationManager == nil {
                     polygonOutlineAnnotationManager = mv.annotations.makePolylineAnnotationManager(
-                        id: "mapbox-ios-polygon-outlines",
+                        id: MapboxBridge.POLYGON_OUTLINE_LAYER_ID,
                         layerPosition: .below(MapboxBridge.MARKER_LAYER_ID)
                     )
                 }

--- a/src/ui-mapbox/index.android.ts
+++ b/src/ui-mapbox/index.android.ts
@@ -669,7 +669,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                                 const annotationPlugin = this._getPlugin<com.mapbox.maps.plugin.annotation.AnnotationPlugin>('MAPBOX_ANNOTATION_PLUGIN_ID');
                                 this.lineManager = annotationPlugin.createAnnotationManager(
                                     com.mapbox.maps.plugin.annotation.AnnotationType.PolylineAnnotation,
-                                    new com.mapbox.maps.plugin.annotation.AnnotationConfig()
+                                    new com.mapbox.maps.plugin.annotation.AnnotationConfig(MarkerManager.LAYER_ID)
                                 ) as com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationManager;
 
                                 this.onAnnotationClickListener = new com.mapbox.maps.plugin.annotation.generated.OnPolylineAnnotationClickListener({
@@ -1754,7 +1754,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                     const annotationPlugin = this._getPlugin<com.mapbox.maps.plugin.annotation.AnnotationPlugin>('MAPBOX_ANNOTATION_PLUGIN_ID');
                     this.polygonManager = annotationPlugin.createAnnotationManager(
                         com.mapbox.maps.plugin.annotation.AnnotationType.PolygonAnnotation,
-                        new com.mapbox.maps.plugin.annotation.AnnotationConfig()
+                        new com.mapbox.maps.plugin.annotation.AnnotationConfig(MarkerManager.LAYER_ID)
                     ) as com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationManager;
                 }
                 const polygonOptions = new com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationOptions();
@@ -1796,7 +1796,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                     const annotationPlugin = this._getPlugin<com.mapbox.maps.plugin.annotation.AnnotationPlugin>('MAPBOX_ANNOTATION_PLUGIN_ID');
                     this.lineManager = annotationPlugin.createAnnotationManager(
                         com.mapbox.maps.plugin.annotation.AnnotationType.PolylineAnnotation,
-                        new com.mapbox.maps.plugin.annotation.AnnotationConfig()
+                        new com.mapbox.maps.plugin.annotation.AnnotationConfig(MarkerManager.LAYER_ID)
                     ) as com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationManager;
                 }
                 const polylineOptions = new com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationOptions();

--- a/src/ui-mapbox/markers/MarkerManager.android.ts
+++ b/src/ui-mapbox/markers/MarkerManager.android.ts
@@ -29,7 +29,7 @@ export class MarkerManager {
         this.mapView = mapView;
         this.onInfoWindowTapped = onInfoWindowClick;
         const AnnotationConfig = com.mapbox.maps.plugin.annotation.AnnotationConfig;
-        const layerConfig = new AnnotationConfig(MarkerManager.LAYER_ID);
+        const layerConfig = new AnnotationConfig(null, MarkerManager.LAYER_ID);
         const annotationPlugin = mapView.getPlugin('MAPBOX_ANNOTATION_PLUGIN_ID') as com.mapbox.maps.plugin.annotation.AnnotationPlugin;
         this.pointAnnotationManager = annotationPlugin.createAnnotationManager(
             com.mapbox.maps.plugin.annotation.AnnotationType.PointAnnotation,


### PR DESCRIPTION
 ## Problem
   On Android ans iOS, annotation layer ordering can cause markers to render below polylines or polygons.

   ## Changes
   This PR updates the Android/iOS annotation manager configuration to use the marker layer ID consistently when creating:
   - polyline annotation manager
   - polygon annotation manager
   - point annotation manager

   ## Result
   Markers render above other annotation layers more consistently.

   ## Scope
   Android/iOS
