### PR TITLE
feat: Add imageSource support for marker rendering

### DIFF
--- a/src/ui-mapbox/common.ts
+++ b/src/ui-mapbox/common.ts
@@ -148,6 +148,11 @@ export interface MapboxMarker extends LatLng {
      */
     iconPath?: string;
     /**
+     * Runtime-generated image used directly as a marker icon.
+     * Useful when the app composes an icon in memory instead of loading it from a resource, file path, or URL.
+     */
+    imageSource?: ImageSource;
+    /**
      * A callback function to invoke when the marker is tapped.
      */
     onTap?: Function;

--- a/src/ui-mapbox/index.android.ts
+++ b/src/ui-mapbox/index.android.ts
@@ -1376,11 +1376,13 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                         console.warn(`No icon found for this device density for icon ' ${marker.icon}'. Falling back to the default icon.`);
                     }
                 } else if (marker.icon.startsWith('http')) {
-                    if (marker.downloadedIcon !== null) {
+                    if (marker.downloadedIcon) {
                         icon = marker.downloadedIcon;
 
                         // markerOptions.setIcon(iconFactory.fromBitmap(marker.iconDownloaded));
                     }
+                } else if (marker.imageSource) {
+                    icon = marker.imageSource;
                 } else {
                     if (Trace.isEnabled()) {
                         CLog(CLogTypes.info, 'Please use res://resourcename, http(s)://imageurl or iconPath to use a local path');
@@ -3566,6 +3568,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
             return marker;
         } catch (error) {
             console.error(error);
+            return marker;
         }
     }
 
@@ -3573,7 +3576,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         const result: MapboxMarker[] = [];
         for (let i = 0; i < markers.length; i++) {
             const marker = markers[i];
-            if (marker.icon && marker.icon.startsWith('http')) {
+            if (marker.imageSource || marker.downloadedIcon) {
+                result.push(marker);
+            } else if (marker.icon && marker.icon.startsWith('http')) {
                 const mark = await this._downloadImage(marker);
                 result.push(mark);
             } else {

--- a/src/ui-mapbox/index.ios.ts
+++ b/src/ui-mapbox/index.ios.ts
@@ -626,7 +626,11 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
                 const updated = await Promise.all(
                     markers.map(async (m) => {
-                        if (m.icon && typeof m.icon === 'string' && m.icon.startsWith('http')) {
+                        if (m.imageSource) {
+                            (m as any).iconDownloaded = m.imageSource.ios;
+                        } else if (m.downloadedIcon) {
+                            (m as any).iconDownloaded = m.downloadedIcon.ios;
+                        } else if (m.icon && typeof m.icon === 'string' && m.icon.startsWith('http')) {
                             (m as any).iconDownloaded = await fetchImageIOS(m.icon);
                         }
                         return m;


### PR DESCRIPTION
## Summary

This PR adds optional `imageSource` support to `MapboxMarker`, so applications can pass a runtime-generated NativeScript `ImageSource` directly as a marker icon.

This is useful for cases where marker icons are created dynamically in the app, for example:
- numbered route markers,
- start / end badges,
- composed marker images generated at runtime.

## Motivation

The current marker API works well for:
- `icon` with `res://...`,
- `iconPath`,
- remote image URLs.

However, these options are not a clean fit for markers that are generated dynamically in memory and already exist as a NativeScript `ImageSource`.

Adding `imageSource` provides a direct and explicit way to support that use case without relying on internal fields or workarounds.

## Changes

- adds optional `imageSource?: ImageSource` to `MapboxMarker`
- uses `imageSource` directly when provided
- preserves existing `icon`, `iconPath`, and remote download behavior

## Compatibility

This change is backward-compatible.

Existing applications using `icon`, `iconPath`, or remote marker images should continue to work as before. The new `imageSource` property is optional and only affects markers that explicitly use it.

## Use case example

A common use case is generating marker icons dynamically in the app, such as route markers with:
- custom numbering, labels and other,
- runtime-composed overlays.

With this change, the generated NativeScript `ImageSource` can be passed directly to the plugin instead of first converting it into a file path or URL-based workflow.
